### PR TITLE
Remove unused dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 function useTimeout(callback, delay) {
   const savedCallback = useRef()
@@ -18,7 +18,7 @@ function useTimeout(callback, delay) {
         savedCallback.current()
       }
       if (delay !== null) {
-        let id = setTimeout(tick, delay)
+        const id = setTimeout(tick, delay)
         return () => clearTimeout(id)
       }
     },


### PR DESCRIPTION
**Summary**

- `React` is only necessary if we're using JSX and `useState` isn't used anywhere so we can drop it.
- `let` -> `const`